### PR TITLE
update haste and metro cache locations for new metro versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ This script has command support for both [npm](https://docs.npmjs.com/cli/npm) a
 - `-j`:
 
   - watchman watch-del-all
-  - rm -rf /tmp/haste-map-react-native-packager-\*
-  - rm -rf /tmp/metro-bundler-cache-\*
-  - *<DEPENDENCY_MANAGER>* cache clean
+  - rm -rf $TMPDIR/haste-map-react-native-packager-\*
+  - rm -rf $TMPDIR/metro-bundler-cache-\*
+  - _<DEPENDENCY_MANAGER>_ cache clean
   - rm -rf ~/.rncache
 
 - `-p`:
@@ -58,11 +58,11 @@ This script has command support for both [npm](https://docs.npmjs.com/cli/npm) a
 - `-m`:
 
   - rm -rf ./node_modules
-  - *<DEPENDENCY_MANAGER>* install
+  - _<DEPENDENCY_MANAGER>_ install
 
 - `-c`:
 
-  - *<DEPENDENCY_MANAGER>* jest --clearCache
+  - _<DEPENDENCY_MANAGER>_ jest --clearCache
 
 ## License
 

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -1,17 +1,22 @@
 const shell = require("shelljs");
 const DEPENDENCY_MANAGER = require("../helpers/dependencyManager");
 
-module.exports = function() {
+// new versions of metro use TMPDIR as cache location
+const TMP_FOLDER = process.env.TMPDIR || "/tmp/";
+
+module.exports = function () {
   console.log("## Javascript clean ##".bold.underline.javascript);
 
   console.log("\n* watchman watch-del-all".javascript);
   shell.exec("watchman watch-del-all", { async: false });
 
-  console.log("\n* rm -rf haste-map-react-native-packager-*".javascript);
-  shell.rm("-rf", "/tmp/haste-map-react-native-packager-*");
+  const HASTE_MAP_LOCATION = `${TMP_FOLDER}haste-*`;
+  console.log(`\n* rm -rf ${HASTE_MAP_LOCATION}`.javascript);
+  shell.rm("-rf", `${HASTE_MAP_LOCATION}`);
 
-  console.log("\n* rm -rf /tmp/metro-bundler-cache-*".javascript);
-  shell.rm("-rf", "/tmp/metro-bundler-cache-*");
+  const METRO_CACHE_LOCATION = `${TMP_FOLDER}metro-*`;
+  console.log(`\n* rm -rf ${METRO_CACHE_LOCATION}`.javascript);
+  shell.rm("-rf", `${METRO_CACHE_LOCATION}`);
 
   console.log(`\n* ${DEPENDENCY_MANAGER} clean cache`.javascript);
   shell.exec(`${DEPENDENCY_MANAGER} cache clean`, { async: false });


### PR DESCRIPTION
In recent versions of react-native, the cache folders can be located thanks to `echo $TMPDIR`. This directory doesn't point necessarily to `/tmp/`.

As a consequence, 
- "rn-game-over -j" does not clean the right cache location.
- a debugging session can be badly impacted when the cache folder is not the right one in the developper current installation.

This PR intends to fix this issue.